### PR TITLE
docs(additionalHeaders): allow additional headers to be sent with the…

### DIFF
--- a/doc/schema.spec.md
+++ b/doc/schema.spec.md
@@ -131,12 +131,24 @@ The `<>` notation us understood as a place holder.
         "accessMethods": { // describes the access methods on /<service>/<resource>/<element> level, i.e the operations you can perform on the element defined in th `objectModel` property
           "get": { // defines the GET method to be performable on /<service>/<resource>/<element> level
             "parameters": {},
+            "additionalHeaders": { // allows additional, non-standard headers specific to the request (optional)
+              "<header>": { // makes the <header> available for transport
+                "isRequired": true, // marks the attribute to be required on each request (optional)
+                "type": "string" // headers are always strings
+              }
+            },
             "usesPermissions": [ // defines which permissions are needed to be present in the auth token to perform the described operation
               "<scope>Read" // A `Read` level permission is needed. <scope> describes and abstract scope, e.g. media => mediaRead
             ]
           },
           "post": { // defines the POST method to be performable on /<service>/<resource>/<element> level to mdoify an element
-            "description": "Lorem Ipsum", // a te
+            "description": "Lorem Ipsum", // a description
+            "additionalHeaders": { // allows additional, non-standard headers specific to the request (optional)
+              "<header>": { // makes the <header> available for transport
+                "isRequired": true, // marks the attribute to be required on each request (optional)
+                "type": "string" // headers are always strings
+              }
+            },
             "parameters": { // holds all all the attributes being able to be modified via POST
               "<stringAttribute>": { // makes the <stringAttribute> available for modification
                 "isRequired": true, // marks the attribute to be required on each request (optional)
@@ -149,6 +161,12 @@ The `<>` notation us understood as a place holder.
           },
           "delete": { // defines the DELETE method to be performable on /<service>/<resource>/<element> level to delete an element
             "parameters": {},
+            "additionalHeaders": { // allows additional, non-standard headers specific to the request (optional)
+              "<header>": { // makes the <header> available for transport
+                "isRequired": true, // marks the attribute to be required on each request (optional)
+                "type": "string" // headers are always strings
+              }
+            },
             "usesPermissions": [ // defines which permissions are needed to be present in the auth token to perform the described operation
               "<scope>Write" // A `Write` level permission is needed. <scope> describes and abstract scope, e.g. media => mediaWrite
             ]
@@ -164,6 +182,12 @@ The `<>` notation us understood as a place holder.
       "accessMethods": {
         "post": { // defines the POST method to be performable on /<service>/<resource>/ level, i.e creat new elements (server side id)
           "description": "Lorem Ipsum amet sit",
+          "additionalHeaders": { // allows additional, non-standard headers specific to the request (optional)
+            "<header>": { // makes the <header> available for transport
+              "isRequired": true, // marks the attribute to be required on each request (optional)
+              "type": "string" // headers are always strings
+            }
+          },
           "parameters": { // holds all the attributes being able to be given when creating new elements via POST
             "<stringAttribute>": { // makes the <stringAttribute> available for creation
               "isRequired": true, // marks the attribute to be required on each request (optional)
@@ -176,6 +200,12 @@ The `<>` notation us understood as a place holder.
         },
         "put": { // defines the PUT method to be performable on /<service>/<resource>/ level, i.e create new elements letting the client decide about the id/name of the element (rarely used)
           "description": "Lorem Ipsum amet sit",
+          "additionalHeaders": { // allows additional, non-standard headers specific to the request (optional)
+            "<header>": { // makes the <header> available for transport
+              "isRequired": true, // marks the attribute to be required on each request (optional)
+              "type": "string" // headers are always strings
+            }
+          },
           "parameters": { // holds all the attributes being able to be given when creating new elements via PUT
             "<stringAttribute>": { // makes the <stringAttribute> available for creation
               "isRequired": true, // marks the attribute to be required on each request (optional)
@@ -191,6 +221,12 @@ The `<>` notation us understood as a place holder.
             // holds all the attributes that can be used with the $sortBy parameter
             "<stringAttribute>": { // makes the <stringAttribute> available for sorting
               "type": "string"
+            }
+          },
+          "additionalHeaders": { // allows additional, non-standard headers specific to the request (optional)
+            "<header>": { // makes the <header> available for transport
+              "isRequired": true, // marks the attribute to be required on each request (optional)
+              "type": "string" // headers are always strings
             }
           },
           "usesPermissions": [


### PR DESCRIPTION
Let additional headers being sent with the request.

This feature is meant to allow sending transient information with the request which are not covered by standard headers of HTTP (WebSocket is ignored as it shall not contain transient information).

Image a feature like vehicle remote control where you want to start the engine or unlock the car. You might want to hand a secret - like a PIN or password - with the request in addition to the Authorization token to allow the control operation. You might generally have the authorization, but legal or security requirements force you to check a secret.

The following example uses the secret "superSecurePassword":
```http
POST /remoteaccess/vehicles/9f9079b2-9383-4ee4-b627-cca0e8444b08 HTTP/1.1
Authorization: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.Ge22Vs5mGdCDjebNl-jMLGzc93tegVpfumHGNqPfO6s
X-Secret: superSecurePassword

{
  "lockState": "unlocked"
}
```

the schema file would hold the following section for elememnt level POST:

```json
...,
"additonalHeaders": {
  "X-Secret": {
    "isRequired": true,
    "type": "string"
  }
},
...
``` 
